### PR TITLE
infer grid types

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -1,2 +1,0 @@
-[default.extend-words]
-"nd-unstructured" = "nd-unstructured"

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,0 +1,2 @@
+[default.extend-words]
+"nd-unstructured" = "nd-unstructured"

--- a/ci/requirements/environment.yaml
+++ b/ci/requirements/environment.yaml
@@ -10,6 +10,7 @@ dependencies:
   - shapely
   - numpy
   - sparse>=0.15
+  - cf-xarray
   - pytest
   - pytest-cov
   - pip

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
   "geoarrow-rust-core>=0.4.0b3",
   "shapely>=2.0",
   "numpy>=2.0",
+  "cf-xarray>=0.9",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,3 +78,8 @@ branch = true
 [tool.coverage.report]
 show_missing = true
 exclude_lines = ["pragma: no cover", "if TYPE_CHECKING"]
+
+[tool.typos.default]
+extend-ignore-words-re = [
+  "nd",
+]

--- a/python/grid_indexing/__init__.py
+++ b/python/grid_indexing/__init__.py
@@ -1,6 +1,7 @@
 from grid_indexing import grid_indexing
 from grid_indexing.grid_indexing import Index  # noqa: F401
+from grid_indexing.grids import infer_grid_type
 
 __doc__ = grid_indexing.__doc__
 if hasattr(grid_indexing, "__all__"):
-    __all__ = grid_indexing.__all__
+    __all__ = grid_indexing.__all__ + ["infer_grid_type"]

--- a/python/grid_indexing/grids.py
+++ b/python/grid_indexing/grids.py
@@ -19,7 +19,7 @@ def infer_grid_type(ds):
     #
     # Needs to inspect values (except for 1d and 2d crs), so must allow
     # computing (so calling `infer_grid_type` should be avoided if possible)
-    if "crs" in ds.coords and "affine_transform" in ds["crs"].attrs:
+    if ds.cf.grid_mapping_names and "GeoTransform" in ds.cf["grid_mapping"].attrs:
         return "2d-crs"
 
     if "longitude" not in ds.cf or "latitude" not in ds.cf:

--- a/python/grid_indexing/grids.py
+++ b/python/grid_indexing/grids.py
@@ -6,8 +6,8 @@ def is_meshgrid(coord):
     return np.all(coord[0, :] == coord[1, :]) or np.all(coord[:, 0] == coord[:, 1])
 
 
-def infer_grid_type(ds, coords=None):
-    # grid types:
+def infer_grid_type(ds):
+    # grid types (all geographic):
     # - 2d crs (affine transform)
     # - 1d orthogonal (rectilinear)
     # - 2d orthogonal (rectilinear)
@@ -15,14 +15,14 @@ def infer_grid_type(ds, coords=None):
     # - "unstructured" 1d
     # - "unstructured" n-d
     #
-    # Needs to inspect values (except for 2d crs), so must allow computing (so
-    # calling `infer_grid_type` should be avoided if possible)
+    # Needs to inspect values (except for 1d and 2d crs), so must allow
+    # computing (so calling `infer_grid_type` should be avoided if possible)
     if "crs" in ds.coords and "affine_transform" in ds["crs"].attrs:
         return "2d-crs"
 
     if "longitude" not in ds.cf or "latitude" not in ds.cf:
         # projected coords or no spatial coords. Raise for now
-        raise ValueError("cannot infer the grid type without geographical coordinates")
+        raise ValueError("cannot infer the grid type without geographic coordinates")
 
     longitude = ds.cf["longitude"]
     latitude = ds.cf["latitude"]
@@ -40,7 +40,7 @@ def infer_grid_type(ds, coords=None):
             return "2d-rectilinear"
         else:
             # must be curvilinear (this is not entirely accurate, but
-            # "n-d-unstructured" is really hard to check)
+            # "nd-unstructured" is really hard to check)
             return "2d-curvilinear"
     else:
         raise ValueError("unable to infer the grid type")

--- a/python/grid_indexing/grids.py
+++ b/python/grid_indexing/grids.py
@@ -1,0 +1,46 @@
+import cf_xarray  # noqa: F401
+import numpy as np
+
+
+def is_meshgrid(coord):
+    return np.all(coord[0, :] == coord[1, :]) or np.all(coord[:, 0] == coord[:, 1])
+
+
+def infer_grid_type(ds, coords=None):
+    # grid types:
+    # - 2d crs (affine transform)
+    # - 1d orthogonal (rectilinear)
+    # - 2d orthogonal (rectilinear)
+    # - 2d curvilinear
+    # - "unstructured" 1d
+    # - "unstructured" n-d
+    #
+    # Needs to inspect values (except for 2d crs), so must allow computing (so
+    # calling `infer_grid_type` should be avoided if possible)
+    if "crs" in ds.coords and "affine_transform" in ds["crs"].attrs:
+        return "2d-crs"
+
+    if "longitude" not in ds.cf or "latitude" not in ds.cf:
+        # projected coords or no spatial coords. Raise for now
+        raise ValueError("cannot infer the grid type without geographical coordinates")
+
+    longitude = ds.cf["longitude"]
+    latitude = ds.cf["latitude"]
+
+    if longitude.ndim == 1 and latitude.ndim == 1:
+        if longitude.dims != latitude.dims:
+            return "1d-rectilinear"
+        else:
+            return "1d-unstructured"
+    elif (longitude.ndim == 2 and latitude.ndim == 2) and (
+        longitude.dims == latitude.dims
+    ):
+        # can be unstructured, rectilinear or curvilinear
+        if is_meshgrid(longitude.data) and is_meshgrid(latitude.data):
+            return "2d-rectilinear"
+        else:
+            # must be curvilinear (this is not entirely accurate, but
+            # "n-d-unstructured" is really hard to check)
+            return "2d-curvilinear"
+    else:
+        raise ValueError("unable to infer the grid type")

--- a/python/grid_indexing/grids.py
+++ b/python/grid_indexing/grids.py
@@ -2,8 +2,10 @@ import cf_xarray  # noqa: F401
 import numpy as np
 
 
-def is_meshgrid(coord):
-    return np.all(coord[0, :] == coord[1, :]) or np.all(coord[:, 0] == coord[:, 1])
+def is_meshgrid(coord1, coord2):
+    return (
+        np.all(coord1[0, :] == coord1[1, :]) and np.all(coord2[:, 0] == coord2[:, 1])
+    ) or (np.all(coord1[:, 0] == coord1[:, 1]) and np.all(coord2[0, :] == coord2[1, :]))
 
 
 def infer_grid_type(ds):
@@ -36,7 +38,7 @@ def infer_grid_type(ds):
         longitude.dims == latitude.dims
     ):
         # can be unstructured, rectilinear or curvilinear
-        if is_meshgrid(longitude.data) and is_meshgrid(latitude.data):
+        if is_meshgrid(longitude.data, latitude.data):
             return "2d-rectilinear"
         else:
             # must be curvilinear (this is not entirely accurate, but

--- a/python/tests/test_grids.py
+++ b/python/tests/test_grids.py
@@ -1,0 +1,70 @@
+import numpy as np
+import pytest
+import xarray as xr
+
+from grid_indexing import grids
+
+
+class TestInferGridType:
+    def test_rectilinear_1d(self):
+        lat = xr.Variable("lat", np.linspace(-10, 10, 3), {"standard_name": "latitude"})
+        lon = xr.Variable("lon", np.linspace(-5, 5, 4), {"standard_name": "longitude"})
+        ds = xr.Dataset(coords={"lat": lat, "lon": lon})
+
+        actual = grids.infer_grid_type(ds)
+        assert actual == "1d-rectilinear"
+
+    def test_rectilinear_2d(self):
+        lat_, lon_ = np.meshgrid(np.linspace(-10, 10, 3), np.linspace(-5, 5, 4))
+        lat = xr.Variable(["y", "x"], lat_, {"standard_name": "latitude"})
+        lon = xr.Variable(["y", "x"], lon_, {"standard_name": "longitude"})
+        ds = xr.Dataset(coords={"lat": lat, "lon": lon})
+
+        actual = grids.infer_grid_type(ds)
+        assert actual == "2d-rectilinear"
+
+    def test_curvilinear_2d(self):
+        lat_ = np.array([[0, 0, 0, 0], [1, 1, 1, 1], [2, 2, 2, 2]])
+        lon_ = np.array([[0, 1, 2, 3], [1, 2, 3, 4], [2, 3, 4, 5]])
+
+        lat = xr.Variable(["y", "x"], lat_, {"standard_name": "latitude"})
+        lon = xr.Variable(["y", "x"], lon_, {"standard_name": "longitude"})
+        ds = xr.Dataset(coords={"lat": lat, "lon": lon})
+
+        actual = grids.infer_grid_type(ds)
+        assert actual == "2d-curvilinear"
+
+    def test_unstructured_1d(self):
+        lat = xr.Variable(
+            "cells", np.linspace(-10, 10, 12), {"standard_name": "latitude"}
+        )
+        lon = xr.Variable(
+            "cells", np.linspace(-5, 5, 12), {"standard_name": "longitude"}
+        )
+        ds = xr.Dataset(coords={"lat": lat, "lon": lon})
+
+        actual = grids.infer_grid_type(ds)
+
+        assert actual == "1d-unstructured"
+
+    def test_crs_2d(self):
+        pass
+
+    def test_missing_spatial_coordinates(self):
+        ds = xr.Dataset()
+
+        with pytest.raises(ValueError, match="without geographic coordinates"):
+            grids.infer_grid_type(ds)
+
+    def test_unknown_grid_type(self):
+        lat = np.linspace(-10, 10, 24).reshape(2, 3, 4)
+        lon = np.linspace(-5, 5, 24).reshape(2, 3, 4)
+        ds = xr.Dataset(
+            coords={
+                "lat": (["y", "x", "z"], lat, {"standard_name": "latitude"}),
+                "lon": (["y", "x", "z"], lon, {"standard_name": "longitude"}),
+            }
+        )
+
+        with pytest.raises(ValueError, match="unable to infer the grid type"):
+            grids.infer_grid_type(ds)

--- a/python/tests/test_grids.py
+++ b/python/tests/test_grids.py
@@ -48,7 +48,25 @@ class TestInferGridType:
         assert actual == "1d-unstructured"
 
     def test_crs_2d(self):
-        pass
+        data = np.linspace(-10, 10, 12).reshape(3, 4)
+        geo_transform = "101985.0 300.0379266750948 0.0 2826915.0 0.0 -300.041782729805"
+
+        ds = xr.Dataset(
+            {"band_data": (["y", "x"], data)},
+            coords={
+                "spatial_ref": (
+                    (),
+                    np.array(0),
+                    {
+                        "grid_mapping_name": "transverse_mercator",
+                        "GeoTransform": geo_transform,
+                    },
+                )
+            },
+        )
+
+        actual = grids.infer_grid_type(ds)
+        assert actual == "2d-crs"
 
     def test_missing_spatial_coordinates(self):
         ds = xr.Dataset()


### PR DESCRIPTION
To be able to properly process different kinds of grids, we need to figure out which grid type we're dealing with. This adds a function that both defines the existing types as well as infers the type of a given dataset.