### PR TITLE
use `cf-xarray` to infer cell geometries

### DIFF
--- a/python/grid_indexing/grids.py
+++ b/python/grid_indexing/grids.py
@@ -59,6 +59,7 @@ def infer_cell_geometries(
     grid_type: str = "infer",
     coords: Literal["infer"] | list[str] = "infer",
 ):
+    # TODO: short-circuit for existing geometries
     if grid_type == "infer":
         grid_type = infer_grid_type(ds)
 
@@ -66,6 +67,12 @@ def infer_cell_geometries(
         raise NotImplementedError(
             "inferring cell geometries is not yet implemented"
             " for geotransform-based grids"
+        )
+    elif grid_type == "1d-unstructured":
+        raise ValueError(
+            "inferring cell geometries is not implemented for unstructured grids."
+            " This is hard to get right in all cases, so please manually"
+            " create the geometries."
         )
 
     if coords == "infer":

--- a/python/grid_indexing/grids.py
+++ b/python/grid_indexing/grids.py
@@ -1,14 +1,16 @@
 import cf_xarray  # noqa: F401
 import numpy as np
+import xarray as xr
+from numpy.typing import ArrayLike
 
 
-def is_meshgrid(coord1, coord2):
+def is_meshgrid(coord1: ArrayLike, coord2: ArrayLike):
     return (
         np.all(coord1[0, :] == coord1[1, :]) and np.all(coord2[:, 0] == coord2[:, 1])
     ) or (np.all(coord1[:, 0] == coord1[:, 1]) and np.all(coord2[0, :] == coord2[1, :]))
 
 
-def infer_grid_type(ds):
+def infer_grid_type(ds: xr.Dataset):
     # grid types (all geographic):
     # - 2d crs (affine transform)
     # - 1d orthogonal (rectilinear)

--- a/python/grid_indexing/grids.py
+++ b/python/grid_indexing/grids.py
@@ -1,3 +1,5 @@
+from typing import Literal
+
 import cf_xarray  # noqa: F401
 import numpy as np
 import xarray as xr
@@ -48,3 +50,30 @@ def infer_grid_type(ds: xr.Dataset):
             return "2d-curvilinear"
     else:
         raise ValueError("unable to infer the grid type")
+
+
+def infer_cell_geometries(
+    ds: xr.Dataset,
+    *,
+    grid_type: str = "infer",
+    coords: Literal["infer"] | list[str] = "infer",
+):
+    if grid_type == "infer":
+        grid_type = infer_grid_type(ds)
+
+    if grid_type == "2d-crs":
+        raise NotImplementedError(
+            "inferring cell geometries is not yet implemented"
+            " for geotransform-based grids"
+        )
+
+    if coords == "infer":
+        coords = ["longitude", "latitude"]
+        if any(coord not in ds.cf.coordinates for coord in coords):
+            raise ValueError(
+                "cannot infer geographic coordinates. Please add them"
+                " or explicitly pass the names if they exist."
+            )
+
+    with_bounds = ds.cf.add_bounds(coords)
+    return with_bounds

--- a/python/tests/test_grids.py
+++ b/python/tests/test_grids.py
@@ -21,8 +21,8 @@ def example_dataset(grid_type):
             lon = xr.Variable(["y", "x"], lon_, {"standard_name": "longitude"})
             ds = xr.Dataset(coords={"lat": lat, "lon": lon})
         case "2d-curvilinear":
-            lat_ = np.array([[0, 0, 0, 0], [1, 1, 1, 1], [2, 2, 2, 2]])
-            lon_ = np.array([[0, 1, 2, 3], [1, 2, 3, 4], [2, 3, 4, 5]])
+            lat_ = np.array([[0, 0, 0], [2, 2, 2]])
+            lon_ = np.array([[0, 2, 4], [2, 4, 6]])
 
             lat = xr.Variable(["y", "x"], lat_, {"standard_name": "latitude"})
             lon = xr.Variable(["y", "x"], lon_, {"standard_name": "longitude"})
@@ -92,7 +92,20 @@ def example_geometries(grid_type):
                 ]
             )
         case "2d-curvilinear":
-            pass
+            boundaries = np.array(
+                [
+                    [
+                        [[-2, -1], [0, -1], [2, 1], [0, 1]],
+                        [[0, -1], [2, -1], [4, 1], [2, 1]],
+                        [[2, -1], [4, -1], [6, 1], [4, 1]],
+                    ],
+                    [
+                        [[0, 1], [2, 1], [4, 3], [2, 3]],
+                        [[2, 1], [4, 1], [6, 3], [4, 3]],
+                        [[4, 1], [6, 1], [8, 3], [6, 3]],
+                    ],
+                ]
+            )
 
     return shapely.polygons(boundaries)
 
@@ -161,9 +174,7 @@ class TestInferCellGeometries:
         [
             "1d-rectilinear",
             "2d-rectilinear",
-            pytest.param(
-                "2d-curvilinear", marks=pytest.mark.xfail(reason="not yet implemented")
-            ),
+            "2d-curvilinear",
             pytest.param(
                 "1d-unstructured", marks=pytest.mark.xfail(reason="not yet implemented")
             ),

--- a/python/tests/test_grids.py
+++ b/python/tests/test_grids.py
@@ -176,9 +176,6 @@ class TestInferCellGeometries:
             "2d-rectilinear",
             "2d-curvilinear",
             pytest.param(
-                "1d-unstructured", marks=pytest.mark.xfail(reason="not yet implemented")
-            ),
-            pytest.param(
                 "2d-crs", marks=pytest.mark.xfail(reason="not yet implemented")
             ),
         ],

--- a/python/tests/test_grids.py
+++ b/python/tests/test_grids.py
@@ -5,68 +5,70 @@ import xarray as xr
 from grid_indexing import grids
 
 
+def example_dataset(grid_type):
+    match grid_type:
+        case "1d-rectilinear":
+            lat = xr.Variable(
+                "lat", np.linspace(-10, 10, 3), {"standard_name": "latitude"}
+            )
+            lon = xr.Variable(
+                "lon", np.linspace(-5, 5, 4), {"standard_name": "longitude"}
+            )
+            ds = xr.Dataset(coords={"lat": lat, "lon": lon})
+        case "2d-rectilinear":
+            lat_, lon_ = np.meshgrid(np.linspace(-10, 10, 3), np.linspace(-5, 5, 4))
+            lat = xr.Variable(["y", "x"], lat_, {"standard_name": "latitude"})
+            lon = xr.Variable(["y", "x"], lon_, {"standard_name": "longitude"})
+            ds = xr.Dataset(coords={"lat": lat, "lon": lon})
+        case "2d-curvilinear":
+            lat_ = np.array([[0, 0, 0, 0], [1, 1, 1, 1], [2, 2, 2, 2]])
+            lon_ = np.array([[0, 1, 2, 3], [1, 2, 3, 4], [2, 3, 4, 5]])
+
+            lat = xr.Variable(["y", "x"], lat_, {"standard_name": "latitude"})
+            lon = xr.Variable(["y", "x"], lon_, {"standard_name": "longitude"})
+            ds = xr.Dataset(coords={"lat": lat, "lon": lon})
+        case "1d-unstructured":
+            lat = xr.Variable(
+                "cells", np.linspace(-10, 10, 12), {"standard_name": "latitude"}
+            )
+            lon = xr.Variable(
+                "cells", np.linspace(-5, 5, 12), {"standard_name": "longitude"}
+            )
+            ds = xr.Dataset(coords={"lat": lat, "lon": lon})
+        case "2d-crs":
+            data = np.linspace(-10, 10, 12).reshape(3, 4)
+            geo_transform = (
+                "101985.0 300.0379266750948 0.0 2826915.0 0.0 -300.041782729805"
+            )
+
+            attrs = {
+                "grid_mapping_name": "transverse_mercator",
+                "GeoTransform": geo_transform,
+            }
+
+            ds = xr.Dataset(
+                {"band_data": (["y", "x"], data)},
+                coords={"spatial_ref": ((), np.array(0), attrs)},
+            )
+
+    return ds
+
+
 class TestInferGridType:
-    def test_rectilinear_1d(self):
-        lat = xr.Variable("lat", np.linspace(-10, 10, 3), {"standard_name": "latitude"})
-        lon = xr.Variable("lon", np.linspace(-5, 5, 4), {"standard_name": "longitude"})
-        ds = xr.Dataset(coords={"lat": lat, "lon": lon})
-
+    @pytest.mark.parametrize(
+        "grid_type",
+        [
+            "1d-rectilinear",
+            "2d-rectilinear",
+            "2d-curvilinear",
+            "1d-unstructured",
+            "2d-crs",
+        ],
+    )
+    def test_infer_grid_type(self, grid_type):
+        ds = example_dataset(grid_type)
         actual = grids.infer_grid_type(ds)
-        assert actual == "1d-rectilinear"
-
-    def test_rectilinear_2d(self):
-        lat_, lon_ = np.meshgrid(np.linspace(-10, 10, 3), np.linspace(-5, 5, 4))
-        lat = xr.Variable(["y", "x"], lat_, {"standard_name": "latitude"})
-        lon = xr.Variable(["y", "x"], lon_, {"standard_name": "longitude"})
-        ds = xr.Dataset(coords={"lat": lat, "lon": lon})
-
-        actual = grids.infer_grid_type(ds)
-        assert actual == "2d-rectilinear"
-
-    def test_curvilinear_2d(self):
-        lat_ = np.array([[0, 0, 0, 0], [1, 1, 1, 1], [2, 2, 2, 2]])
-        lon_ = np.array([[0, 1, 2, 3], [1, 2, 3, 4], [2, 3, 4, 5]])
-
-        lat = xr.Variable(["y", "x"], lat_, {"standard_name": "latitude"})
-        lon = xr.Variable(["y", "x"], lon_, {"standard_name": "longitude"})
-        ds = xr.Dataset(coords={"lat": lat, "lon": lon})
-
-        actual = grids.infer_grid_type(ds)
-        assert actual == "2d-curvilinear"
-
-    def test_unstructured_1d(self):
-        lat = xr.Variable(
-            "cells", np.linspace(-10, 10, 12), {"standard_name": "latitude"}
-        )
-        lon = xr.Variable(
-            "cells", np.linspace(-5, 5, 12), {"standard_name": "longitude"}
-        )
-        ds = xr.Dataset(coords={"lat": lat, "lon": lon})
-
-        actual = grids.infer_grid_type(ds)
-
-        assert actual == "1d-unstructured"
-
-    def test_crs_2d(self):
-        data = np.linspace(-10, 10, 12).reshape(3, 4)
-        geo_transform = "101985.0 300.0379266750948 0.0 2826915.0 0.0 -300.041782729805"
-
-        ds = xr.Dataset(
-            {"band_data": (["y", "x"], data)},
-            coords={
-                "spatial_ref": (
-                    (),
-                    np.array(0),
-                    {
-                        "grid_mapping_name": "transverse_mercator",
-                        "GeoTransform": geo_transform,
-                    },
-                )
-            },
-        )
-
-        actual = grids.infer_grid_type(ds)
-        assert actual == "2d-crs"
+        assert actual == grid_type
 
     def test_missing_spatial_coordinates(self):
         ds = xr.Dataset()

--- a/python/tests/test_grids.py
+++ b/python/tests/test_grids.py
@@ -132,9 +132,21 @@ class TestInferGridType:
 
 
 class TestInferCellGeometries:
-    def test_crs_not_supported(self):
-        ds = example_dataset("2d-crs")
-        with pytest.raises(NotImplementedError, match="geotransform"):
+    @pytest.mark.parametrize(
+        ["grid_type", "error", "pattern"],
+        (
+            pytest.param("2d-crs", NotImplementedError, "geotransform", id="2d-crs"),
+            pytest.param(
+                "1d-unstructured",
+                ValueError,
+                "unstructured grids",
+                id="1d-unstructured",
+            ),
+        ),
+    )
+    def test_not_supported(self, grid_type, error, pattern):
+        ds = example_dataset(grid_type)
+        with pytest.raises(error, match=pattern):
             grids.infer_cell_geometries(ds)
 
     def test_infer_coords(self):

--- a/python/tests/test_grids.py
+++ b/python/tests/test_grids.py
@@ -88,3 +88,15 @@ class TestInferGridType:
 
         with pytest.raises(ValueError, match="unable to infer the grid type"):
             grids.infer_grid_type(ds)
+
+
+class TestInferCellGeometries:
+    def test_crs_not_supported(self):
+        ds = example_dataset("2d-crs")
+        with pytest.raises(NotImplementedError, match="geotransform"):
+            grids.infer_cell_geometries(ds)
+
+    def test_infer_coords(self):
+        ds = xr.Dataset()
+        with pytest.raises(ValueError, match="cannot infer geographic coordinates"):
+            grids.infer_cell_geometries(ds, grid_type="2d-rectilinear")


### PR DESCRIPTION
- [x] follow-up to #13

To make working with datasets easier, this allows inferring the cell geometries from coordinates. This won't work for unrecognized grids (see `infer_grid_type`) and unstructured grids, while it could work for `2d-crs` (the geotransform) but this will be punted to a separate PR.