### PR TITLE
use geoarrow instead of shapely to construct polygons

### DIFF
--- a/python/tests/test_grids.py
+++ b/python/tests/test_grids.py
@@ -1,3 +1,4 @@
+import geoarrow.rust.core as geoarrow
 import numpy as np
 import pytest
 import shapely
@@ -186,4 +187,5 @@ class TestInferCellGeometries:
 
         actual = grids.infer_cell_geometries(ds, grid_type=grid_type)
 
-        shapely.testing.assert_geometries_equal(actual, expected)
+        actual_geoms = np.reshape(geoarrow.to_shapely(actual), expected.shape)
+        shapely.testing.assert_geometries_equal(actual_geoms, expected)


### PR DESCRIPTION
Since we're using `geoarrow` anyways, it is worth constructing a `geoarrow` polygon array from the boundaries instead of going through `shapely`.