### PR TITLE
split the index crate into rust and python crates

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -72,6 +72,8 @@ jobs:
 
       - name: Create rust cache
         uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: "py${{ matrix.python-version }}"
 
       - name: Help finding installed libraries
         run: |

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -74,6 +74,8 @@ jobs:
 
       - name: Create rust cache
         uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: "py${{ matrix.python-version }}"
 
       - name: Help finding installed libraries
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
     hooks:
       - id: validate-pyproject
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.2
+    rev: v0.11.4
     hooks:
       - id: ruff
         args: ["--fix", "--show-fixes"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,7 +48,7 @@ repos:
         args:
           - "--extra-keys=metadata.kernelspec"
           - "metadata.language_info.version"
-  - repo: https://github.com/crate-ci/typos
+  - repo: https://github.com/adhtruong/mirrors-typos
     rev: v1.31.1
     hooks:
       - id: typos

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,7 +49,7 @@ repos:
           - "--extra-keys=metadata.kernelspec"
           - "metadata.language_info.version"
   - repo: https://github.com/crate-ci/typos
-    rev: v1
+    rev: v1.31.1
     hooks:
       - id: typos
         exclude: ".*\\.ipynb$"

--- a/ci/requirements/environment.yaml
+++ b/ci/requirements/environment.yaml
@@ -14,6 +14,8 @@ dependencies:
   - cf-xarray
   - pytest
   - pytest-cov
+  - dask
+  - distributed
   - pip
   - pip:
       - geoarrow-rust-core==0.4.0b3

--- a/python/grid_indexing/__init__.py
+++ b/python/grid_indexing/__init__.py
@@ -1,5 +1,5 @@
 from grid_indexing import grid_indexing, tutorial
-from grid_indexing.grid_indexing import Index, create_empty  # noqa: F401
+from grid_indexing.grid_indexing import RTree, create_empty  # noqa: F401
 from grid_indexing.grids import infer_cell_geometries, infer_grid_type
 
 __all__ = ["infer_grid_type", "infer_cell_geometries", "tutorial"]

--- a/python/grid_indexing/distributed.py
+++ b/python/grid_indexing/distributed.py
@@ -5,7 +5,7 @@ import numpy as np
 import shapely
 import sparse
 
-from grid_indexing import Index
+from grid_indexing import RTree
 
 
 def _chunk_boundaries(chunk):
@@ -16,7 +16,7 @@ def _chunk_boundaries(chunk):
 
 
 def _index_from_shapely(chunk):
-    return Index(ga.from_shapely(chunk.flatten()))
+    return RTree(ga.from_shapely(chunk.flatten()))
 
 
 def _empty_chunk(index, chunk, shape):
@@ -99,7 +99,7 @@ class DistributedRTree:
         ).compute()
 
         self.chunk_indexes = self.source_grid.map(dask.delayed(_index_from_shapely))
-        self.index = Index.from_shapely(np.array(boundaries))
+        self.index = RTree.from_shapely(np.array(boundaries))
 
     def query_overlap(self, geoms):
         import dask

--- a/python/grid_indexing/distributed.py
+++ b/python/grid_indexing/distributed.py
@@ -70,7 +70,8 @@ class ChunkGrid:
 
         for flat_index in range(size):
             indices = tuple(map(int, np.unravel_index(flat_index, shape)))
-            chunk_shape = tuple(map(int, self.chunksizes[*indices, :]))
+
+            chunk_shape = tuple(map(int, self.chunksizes[indices + (slice(None),)]))
 
             yield indices, chunk_shape, self.delayed[indices]
 

--- a/python/grid_indexing/tests/test_distributed.py
+++ b/python/grid_indexing/tests/test_distributed.py
@@ -8,7 +8,7 @@ import numpy as np
 import shapely
 import shapely.testing
 
-from grid_indexing import Index
+from grid_indexing import RTree
 from grid_indexing.distributed import (
     ChunkGrid,
     DistributedRTree,
@@ -216,7 +216,7 @@ class TestDistributedRTree:
         source_grid = example_grid.reshape(2, 2)
         chunked_polygons = da.from_array(source_grid, chunks=(2, 1))
 
-        index = Index.from_shapely(source_grid.flatten())
+        index = RTree.from_shapely(source_grid.flatten())
         distributed_index = DistributedRTree(chunked_polygons)
 
         chunked_query = da.from_array(example_query, chunks=chunks)

--- a/python/grid_indexing/tests/test_rtree.py
+++ b/python/grid_indexing/tests/test_rtree.py
@@ -5,7 +5,7 @@ import numpy as np
 import shapely
 import sparse
 
-from grid_indexing import Index
+from grid_indexing import RTree
 
 
 def create_cells(x, y):
@@ -32,8 +32,8 @@ def test_create_index_from_shapely():
 
     cells = create_cells(x, y).flatten()
 
-    index = Index(geoarrow.from_shapely(cells))
-    assert isinstance(index, Index)
+    index = RTree(geoarrow.from_shapely(cells))
+    assert isinstance(index, RTree)
 
 
 def test_create_index_geoarrow():
@@ -42,8 +42,8 @@ def test_create_index_geoarrow():
 
     cells = create_cells(x, y).flatten()
 
-    index = Index.from_shapely(cells)
-    assert isinstance(index, Index)
+    index = RTree.from_shapely(cells)
+    assert isinstance(index, RTree)
 
 
 def test_query_overlap():
@@ -52,7 +52,7 @@ def test_query_overlap():
     ).flatten()
     target_cells = source_cells
 
-    index = Index.from_shapely(source_cells)
+    index = RTree.from_shapely(source_cells)
 
     actual = index.query_overlap(geoarrow.from_shapely(target_cells))
 
@@ -69,11 +69,11 @@ def test_pickle():
 
     cells = create_cells(x, y).flatten()
 
-    index = Index.from_shapely(cells)
+    index = RTree.from_shapely(cells)
 
     dumped = pickle.dumps(index)
     recreated = pickle.loads(dumped)
 
-    assert isinstance(recreated, Index)
+    assert isinstance(recreated, RTree)
     # TODO: compare the index
     # assert index == recreated

--- a/src/index.rs
+++ b/src/index.rs
@@ -122,10 +122,10 @@ mod tests {
 
         let array2 = PolygonArray::from((
             vec![
-                bbox(coord! {x:0.0, y: 0.0}, coord! {x: 1.0, y: 1.0}),
-                bbox(coord! {x:1.0, y: 0.0}, coord! {x: 2.0, y: 1.0}),
-                bbox(coord! {x:0.0, y: 1.0}, coord! {x: 1.0, y: 2.0}),
-                bbox(coord! {x:1.0, y: 1.0}, coord! {x: 2.0, y: 2.0}),
+                bbox(coord! {x: 0.0, y: 0.0}, coord! {x: 1.0, y: 1.0}),
+                bbox(coord! {x: 1.0, y: 0.0}, coord! {x: 2.0, y: 1.0}),
+                bbox(coord! {x: 0.0, y: 1.0}, coord! {x: 1.0, y: 2.0}),
+                bbox(coord! {x: 1.0, y: 1.0}, coord! {x: 2.0, y: 2.0}),
             ],
             Dimension::XY,
         ));

--- a/src/index.rs
+++ b/src/index.rs
@@ -69,6 +69,16 @@ mod tests {
         Some(Rect::new(ll, ur).to_polygon())
     }
 
+    fn normalize_result(result: Vec<Vec<usize>>) -> Vec<Vec<usize>> {
+        result
+            .into_iter()
+            .map(|mut v| {
+                v.sort();
+                v
+            })
+            .collect::<Vec<_>>()
+    }
+
     #[test]
     fn test_create_from_polygon_array() {
         let polygon1 = Polygon::new(
@@ -130,5 +140,32 @@ mod tests {
             Dimension::XY,
         ));
         assert_eq!(CellRTree::create(array2).size(), 4);
+    }
+
+    #[test]
+    fn test_overlaps_rectilinear() {
+        let source = PolygonArray::from((
+            vec![
+                bbox(coord! {x: 0.0, y: 0.0}, coord! {x: 1.0, y: 1.0}),
+                bbox(coord! {x: 1.0, y: 0.0}, coord! {x: 2.0, y: 1.0}),
+                bbox(coord! {x: 0.0, y: 1.0}, coord! {x: 1.0, y: 2.0}),
+                bbox(coord! {x: 1.0, y: 1.0}, coord! {x: 2.0, y: 2.0}),
+            ],
+            Dimension::XY,
+        ));
+        let index = CellRTree::create(source);
+
+        let target = PolygonArray::from((
+            vec![
+                bbox(coord! {x: 0.2, y: 0.0}, coord! {x: 1.5, y: 1.0}),
+                bbox(coord! {x: 0.6, y: 1.2}, coord! {x: 0.9, y: 1.8}),
+                bbox(coord! {x: 0.3, y: 0.2}, coord! {x: 1.3, y: 1.6}),
+                bbox(coord! {x: 2.1, y: 2.3}, coord! {x: 2.7, y: 3.1}),
+            ],
+            Dimension::XY,
+        ));
+        let actual = index.overlaps(&target);
+        let expected: Vec<Vec<usize>> = vec![vec![0, 1], vec![2], vec![0, 1, 2, 3], vec![]];
+        assert_eq!(normalize_result(actual), expected);
     }
 }

--- a/src/index.rs
+++ b/src/index.rs
@@ -169,4 +169,28 @@ mod tests {
         let expected: Vec<Vec<usize>> = vec![vec![0, 1], vec![2], vec![0, 1, 2, 3], vec![]];
         assert_eq!(normalize_result(actual), expected);
     }
+
+    /// check touches
+    #[test]
+    fn test_overlaps_touches() {
+        let source = PolygonArray::from((
+            vec![
+                bbox(coord! {x: 0.0, y: 0.0}, coord! {x: 1.0, y: 1.0}),
+                bbox(coord! {x: 1.0, y: 0.0}, coord! {x: 2.0, y: 1.0}),
+            ],
+            Dimension::XY,
+        ));
+        let index = CellRTree::create(source);
+
+        let target = PolygonArray::from((
+            vec![
+                bbox(coord! {x: 0.0, y: 1.0}, coord! {x: 1.0, y: 2.0}),
+                bbox(coord! {x: 2.0, y: 0.0}, coord! {x: 3.0, y: 1.0}),
+            ],
+            Dimension::XY,
+        ));
+        let actual = index.overlaps(&target);
+        let expected: Vec<Vec<usize>> = vec![vec![], vec![]];
+        assert_eq!(normalize_result(actual), expected);
+    }
 }

--- a/src/index.rs
+++ b/src/index.rs
@@ -142,6 +142,7 @@ mod tests {
         assert_eq!(CellRTree::create(array2).size(), 4);
     }
 
+    /// check the basic functionality of the overlap search
     #[test]
     fn test_overlaps_rectilinear() {
         let source = PolygonArray::from((

--- a/src/index.rs
+++ b/src/index.rs
@@ -69,6 +69,10 @@ mod tests {
         Some(Rect::new(ll, ur).to_polygon())
     }
 
+    fn polygon(exterior: Vec<(f64, f64)>) -> Option<Polygon> {
+        Some(Polygon::new(LineString::from(exterior), vec![]))
+    }
+
     fn normalize_result(result: Vec<Vec<usize>>) -> Vec<Vec<usize>> {
         result
             .into_iter()
@@ -191,6 +195,43 @@ mod tests {
         ));
         let actual = index.overlaps(&target);
         let expected: Vec<Vec<usize>> = vec![vec![], vec![]];
+        assert_eq!(normalize_result(actual), expected);
+    }
+
+    /// check that the additional filter works properly
+    #[test]
+    fn test_overlaps_tilted() {
+        let source = PolygonArray::from((
+            vec![
+                polygon(vec![
+                    (0.0, 0.0),
+                    (1.0, 0.0),
+                    (1.5, 1.0),
+                    (0.5, 1.0),
+                    (0.0, 0.0),
+                ]),
+                polygon(vec![
+                    (1.0, 0.0),
+                    (2.0, 0.0),
+                    (2.5, 1.0),
+                    (1.5, 1.0),
+                    (1.0, 0.0),
+                ]),
+            ],
+            Dimension::XY,
+        ));
+        let index = CellRTree::create(source);
+
+        let target = PolygonArray::from((
+            vec![
+                bbox(coord! {x: -1.0, y: 0.8}, coord! {x: 0.2, y: 1.5}),
+                bbox(coord! {x: 2.4, y: 0.9}, coord! {x: 3.0, y: 2.0}),
+            ],
+            Dimension::XY,
+        ));
+
+        let actual = index.overlaps(&target);
+        let expected: Vec<Vec<usize>> = vec![vec![], vec![1]];
         assert_eq!(normalize_result(actual), expected);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,15 +1,16 @@
 use pyo3::prelude::*;
 
 mod index;
+mod python;
 mod rtreeobject;
 mod trait_;
 
-use self::index::{create_empty, Index};
+use self::python::{create_empty, RTree};
 
 /// A Python module implemented in Rust.
 #[pymodule]
 fn grid_indexing(m: &Bound<'_, PyModule>) -> PyResult<()> {
-    m.add_class::<Index>()?;
+    m.add_class::<RTree>()?;
     m.add_function(wrap_pyfunction!(create_empty, m)?)?;
 
     Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 use pyo3::prelude::*;
 
 mod index;
+mod rtreeobject;
 mod trait_;
 
 use self::index::{create_empty, Index};

--- a/src/python.rs
+++ b/src/python.rs
@@ -1,0 +1,91 @@
+use super::index::CellRTree;
+use super::trait_::{AsPolygonArray, AsSparse};
+use bincode::{deserialize, serialize};
+use geoarrow::array::ArrayBase;
+use pyo3::exceptions::PyRuntimeError;
+use pyo3::intern;
+use pyo3::prelude::*;
+use pyo3::types::{IntoPyDict, PyBytes, PyType};
+use pyo3_arrow::PyArray;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Debug)]
+#[pyclass]
+#[pyo3(module = "grid_indexing")]
+pub struct RTree {
+    tree: CellRTree,
+}
+
+#[pyfunction]
+pub fn create_empty() -> RTree {
+    RTree {
+        tree: CellRTree::empty(),
+    }
+}
+
+#[pymethods]
+impl RTree {
+    #[new]
+    pub fn new(source_cells: PyArray) -> PyResult<Self> {
+        let polygons = source_cells.into_polygon_array();
+
+        polygons.map(|arr| RTree {
+            tree: CellRTree::create(arr),
+        })
+    }
+
+    pub fn __setstate__(&mut self, state: &[u8]) -> PyResult<()> {
+        // Deserialize the data contained in the PyBytes object
+        // and update the struct with the deserialized values.
+        *self = deserialize(state).map_err(|err| PyRuntimeError::new_err(err.to_string()))?;
+
+        Ok(())
+    }
+
+    pub fn __getstate__<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyBytes>> {
+        // Serialize the struct and return a PyBytes object
+        // containing the serialized data.
+        let serialized = serialize(&self).map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
+        let bytes = PyBytes::new(py, &serialized);
+        Ok(bytes)
+    }
+
+    pub fn __reduce__(&self, py: Python) -> PyResult<(PyObject, PyObject, PyObject)> {
+        let create = py.import("grid_indexing")?.getattr("create_empty")?;
+        let args = ();
+        let state = self.__getstate__(py)?;
+
+        Ok((
+            create.into_pyobject(py)?.unbind().into_any(),
+            args.into_pyobject(py)?.unbind().into_any(),
+            state.into_pyobject(py)?.unbind().into_any(),
+        ))
+    }
+
+    #[classmethod]
+    pub fn from_shapely(_cls: &Bound<'_, PyType>, geoms: &Bound<PyAny>) -> PyResult<Self> {
+        let array = Python::with_gil(|py| {
+            let geoarrow = PyModule::import(py, "geoarrow.rust.core")?;
+            let crs = intern!(py, "epsg:4326");
+
+            let kwargs = [("crs", crs)].into_py_dict(py)?;
+
+            let pyobj = geoarrow
+                .getattr("from_shapely")?
+                .call((geoms,), Some(&kwargs))?;
+
+            PyArray::extract_bound(&pyobj)
+        })?;
+
+        Self::new(array)
+    }
+
+    pub fn query_overlap(&self, target_cells: PyArray) -> PyResult<Py<PyAny>> {
+        let polygons = target_cells.into_polygon_array()?;
+
+        self.tree
+            .overlaps(&polygons)
+            .into_sparse((polygons.len(), self.tree.size()))
+    }
+}

--- a/src/rtreeobject.rs
+++ b/src/rtreeobject.rs
@@ -1,0 +1,35 @@
+use geo::Polygon;
+use rstar::{primitives::CachedEnvelope, RTreeObject};
+use serde::{Deserialize, Serialize};
+use std::ops::Deref;
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct NumberedCell {
+    index: usize,
+    envelope: CachedEnvelope<Polygon>,
+}
+
+impl NumberedCell {
+    pub fn new(idx: usize, geom: Polygon) -> Self {
+        NumberedCell {
+            index: idx,
+            envelope: CachedEnvelope::<Polygon>::new(geom),
+        }
+    }
+
+    pub fn geometry(&self) -> &Polygon {
+        self.envelope.deref()
+    }
+
+    pub fn index(&self) -> usize {
+        self.index
+    }
+}
+
+impl RTreeObject for NumberedCell {
+    type Envelope = <CachedEnvelope<Polygon> as RTreeObject>::Envelope;
+
+    fn envelope(&self) -> Self::Envelope {
+        self.envelope.envelope()
+    }
+}


### PR DESCRIPTION
So far, the index crate has provided both the rust class as well as the python methods, causing the result to be quite messy. This splits both into separate classes, with the python class wrapping the rust class.

Additionally, this finally adds a bunch of tests for the rust index.