### PR TITLE
`query` as a entrypoint to all query methods

### DIFF
--- a/python/grid_indexing/distributed.py
+++ b/python/grid_indexing/distributed.py
@@ -142,3 +142,9 @@ class DistributedRTree:
                 output_chunks[indices] = chunk
 
         return da.block(output_chunks.tolist())
+
+    def query(self, geoms, *, method):
+        if method == "overlaps":
+            return self.query_overlap(geoms)
+        else:
+            raise ValueError(f"unknown query mode: {method}")

--- a/python/grid_indexing/tests/test_rtree.py
+++ b/python/grid_indexing/tests/test_rtree.py
@@ -77,3 +77,21 @@ def test_pickle():
     assert isinstance(recreated, RTree)
     # TODO: compare the index
     # assert index == recreated
+
+
+def test_query():
+    source_cells = create_cells(np.linspace(-10, 10, 6), np.linspace(40, 60, 4))
+    target_cells = source_cells
+
+    index = RTree.from_shapely(source_cells)
+    actual = index.query(
+        geoarrow.from_shapely(target_cells.flatten()),
+        shape=target_cells.shape,
+        method="overlaps",
+    )
+
+    assert isinstance(actual, sparse.GCXS)
+    sum_ = np.sum(actual, axis=(1, 2)).todense()
+    assert np.all(
+        np.isin(sum_, np.array([1, 4, 6, 9]))
+    ), "unexpected number of cells found"


### PR DESCRIPTION
This is a convenience wrapper for all the other methods, which is particularly useful in `grid-weights`' `xarray` API.